### PR TITLE
Change indentation style and make dependencies stable

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,7 +10,7 @@ spaces_around_operators = true
 spaces_around_brackets = true
 
 [*.{js,astro,svelte,html,css,json}]
-indent_style = tab
+indent_style = space
 indent_size = 2
 
 [*.{py,md}]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "control-horas",
   "type": "module",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
@@ -10,14 +10,14 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@astrojs/svelte": "^5.0.3",
-    "@astrojs/tailwind": "^5.1.0",
-    "astro": "^4.3.7",
-    "svelte": "^4.2.10",
-    "tailwindcss": "^3.4.1"
+    "@astrojs/svelte": "5.0.3",
+    "@astrojs/tailwind": "5.1.0",
+    "astro": "4.3.7",
+    "svelte": "4.2.10",
+    "tailwindcss": "3.4.1"
   },
   "devDependencies": {
-    "standard": "^17.1.0"
+    "standard": "17.1.0"
   },
   "eslintConfig": {
     "extends": "standard"


### PR DESCRIPTION
Change the indentation style to work with JS Standard specifications.
Delete the `^` of the dependencies to avoid updating them and changing project configurations.