### PR TITLE
Change indentation and dependencies version

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,7 +10,7 @@ spaces_around_operators = true
 spaces_around_brackets = true
 
 [*.{js,astro,svelte,html,css,json}]
-indent_style = tab
+indent_style = space
 indent_size = 2
 
 [*.{py,md}]

--- a/package.json
+++ b/package.json
@@ -10,14 +10,14 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@astrojs/svelte": "^5.0.3",
-    "@astrojs/tailwind": "^5.1.0",
-    "astro": "^4.3.7",
-    "svelte": "^4.2.10",
-    "tailwindcss": "^3.4.1"
+    "@astrojs/svelte": "5.0.3",
+    "@astrojs/tailwind": "5.1.0",
+    "astro": "4.3.7",
+    "svelte": "4.2.10",
+    "tailwindcss": "3.4.1"
   },
   "devDependencies": {
-    "standard": "^17.1.0"
+    "standard": "17.1.0"
   },
   "eslintConfig": {
     "extends": "standard"


### PR DESCRIPTION
Change the indentation form from `tab` to `space` to comply with the Standard JavaScript specification.
Change the versions of the dependencies to fixed and stable versions.