### PR TITLE
footer-center#93

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -6,7 +6,7 @@ import XTwitter from "@/icons/X-twitter.astro"
 
 <footer class="bg-secondary py-8 text-white">
 	<section
-		class="justify-right mx-auto flex max-w-screen-xl flex-wrap md:flex-row md:justify-between"
+		class="mx-auto flex max-w-screen-xl flex-wrap justify-evenly md:flex-row md:justify-between"
 	>
 		<article class="mx-4 mb-6 flex w-1/3 max-w-screen-xl flex-col md:mx-8 md:mb-0 md:w-auto">
 			<h3 class="mb-2 text-lg font-bold lg:text-xl">Sobre Nosotros</h3>


### PR DESCRIPTION
Hola @JuanCarlosAcostaPeraba ;

¿Que te parece mi propuesta? Tambien me gusto usando beetwwen que lo pegaba a las dos paredes, pero entiendo la solicitud es centrar el footer sin perder el acomodo de los article.

![image](https://github.com/PS-G1-Lab/control-horas/assets/10810956/9fbb7a75-6f91-4941-b131-870c368ee1ae)

Espero sirva esta pequeña aportación y pueda atender mas issues.
Saludos.